### PR TITLE
fix tapatrion.lua

### DIFF
--- a/tapatrion.lua
+++ b/tapatrion.lua
@@ -6,7 +6,7 @@ utils.remove_tech("concrete", true, true)
 utils.remove_tech("landfill", true, true)
 utils.remove_tech("steel-processing", true, true)
 
-utils.set_prerequisites("heat-inserter", "heating-tower")
+utils.set_prerequisites("heat-inserter", {"heating-tower"})
 
 utils.set_trigger("agriculture", {type = "mine-entity", entity = "stingfrond"})
 utils.set_trigger("heating-tower", {type = "mine-entity", entity = "sunnycomb"})


### PR DESCRIPTION
Technology prerequisites should be set as string[] not string.

Fixes bug report against my mod, https://mods.factorio.com/mod/atan-nuclear-science/discussion/67c1ad2922369d7a44e82618